### PR TITLE
Umstellung des Apache und HAproxy für den PM-Server Port-Wechsel

### DIFF
--- a/files/09-haproxy-fiona-webproxy.cfg
+++ b/files/09-haproxy-fiona-webproxy.cfg
@@ -13,5 +13,5 @@ listen fiona
 
         default-server maxconn 2000 rise 3 fall 1 weight 50
 
-        server cms-live-pm4 cms-live-pm4.verwaltung.uni-muenchen.de:80 cookie f0401 check observe layer7
-        server cms-live-pm5 cms-live-pm5.verwaltung.uni-muenchen.de:80 cookie f0501 check observe layer7 backup
+        server cms-live-pm4 cms-live-pm4.verwaltung.uni-muenchen.de:8080 cookie f0401 check observe layer7
+        server cms-live-pm5 cms-live-pm5.verwaltung.uni-muenchen.de:8080 cookie f0501 check observe layer7 backup

--- a/templates/zuv-intranet.webproxy.verwaltung.uni-muenchen.de.conf.j2
+++ b/templates/zuv-intranet.webproxy.verwaltung.uni-muenchen.de.conf.j2
@@ -108,6 +108,7 @@ worker-src 'self' data: blob: mediastream: https://cms-static.uni-muenchen.de ht
         ProxyPass http://127.0.0.1:6081
         ProxyPassReverse http://127.0.0.1:6081
         Header set X-Backend-For Fiona
+        RequestHeader set Host www.intranet.verwaltung.uni-muenchen.de:8080
         RequestHeader set X-Backend-For Fiona
     </LocationMatch>
 

--- a/templates/zuv-intranet.webproxy.verwaltung.uni-muenchen.de.conf.j2
+++ b/templates/zuv-intranet.webproxy.verwaltung.uni-muenchen.de.conf.j2
@@ -109,6 +109,7 @@ worker-src 'self' data: blob: mediastream: https://cms-static.uni-muenchen.de ht
         ProxyPassReverse http://127.0.0.1:6081
         Header set X-Backend-For Fiona
         RequestHeader set Host www.intranet.verwaltung.uni-muenchen.de:8080
+        RequestHeader set X-Forwarded-Host www.intranet.verwaltung.uni-muenchen.de
         RequestHeader set X-Backend-For Fiona
     </LocationMatch>
 

--- a/templates/zuv-serviceportal.webproxy.verwaltung.uni-muenchen.de.conf.j2
+++ b/templates/zuv-serviceportal.webproxy.verwaltung.uni-muenchen.de.conf.j2
@@ -112,6 +112,7 @@ worker-src 'self' data: blob: mediastream: https://cms-static.uni-muenchen.de ht
         ProxyPass http://127.0.0.1:6081
         ProxyPassReverse http://127.0.0.1:6081
         Header set X-Backend-For Fiona
+        RequestHeader set Host www.serviceportal.verwaltung.uni-muenchen.de:8080
         RequestHeader set X-Backend-For Fiona
     </LocationMatch>
 

--- a/templates/zuv-serviceportal.webproxy.verwaltung.uni-muenchen.de.conf.j2
+++ b/templates/zuv-serviceportal.webproxy.verwaltung.uni-muenchen.de.conf.j2
@@ -113,6 +113,7 @@ worker-src 'self' data: blob: mediastream: https://cms-static.uni-muenchen.de ht
         ProxyPassReverse http://127.0.0.1:6081
         Header set X-Backend-For Fiona
         RequestHeader set Host www.serviceportal.verwaltung.uni-muenchen.de:8080
+        RequestHeader set X-Forwarded-Host www.serviceportal.verwaltung.uni-muenchen.de
         RequestHeader set X-Backend-For Fiona
     </LocationMatch>
 


### PR DESCRIPTION
Die PM server sollen von Port 80 auf 8080 umgestellt werden. 
Hierz anpasungen im HAproxy und den Apache Configs notwendig.